### PR TITLE
add actual support for focus key

### DIFF
--- a/itermocil.py
+++ b/itermocil.py
@@ -549,11 +549,16 @@ class Itermocil(object):
                     # pane entries may be lists of multiple commands
                     if isinstance(pane, dict):
                         if 'commands' in pane:
-                            pane_name = pane.get('name', None)
                             for command in pane['commands']:
                                 escaped_command = command.replace('"', r'\"')
                                 pane_commands.append(escaped_command)
+
+                        if 'name' in pane:
+                            pane_name = pane.get('name', None)
+
+                        if 'focus' in pane:
                             focus_pane = pane_num
+
                     else:
                         escaped_command = pane.replace('"', r'\"')
                         pane_commands.append(escaped_command)


### PR DESCRIPTION
currently the `focus` key doesn't actually exist, and itermocil would focus on the last pane with a `commands` array on it. this wouldn't work in some my layouts, such as this one:
```yaml
windows:
  - name: github.io
    root: ~/Sites/galaxyutii.github.io
    layout: main-vertical
    panes:
      - name: "github.io"
        commands: 
        - clear
        focus: true
      - name: "github.io: jekyll"
        commands:
        - bundle install
        - clear
        - bundle exec jekyll build --quiet
        - bundle exec jekyll serve --watch
      - name: "github.io: git"
        commands: 
        - clear
        - git status
```

i changed the `itermocil.py` script to look for a `focus` key under each pane and use that to determine which pane to focus on.

i also made the `name` key independent of a `commands` array just in case someone wants to set the name of a pane without performing any special commands in it.