### PR TITLE
add support for iTerm profile specification in yaml file

### DIFF
--- a/itermocil.py
+++ b/itermocil.py
@@ -55,8 +55,12 @@ class Itermocil(object):
         # to script.
         if not self.here:
             if self.new_iterm:
+                if 'profile' in self.teamocil_config['windows'][0]['panes'][0]:
+                    new_profile = 'profile "' + self.teamocil_config['windows'][0]['panes'][0]['profile'] + '"'
+                else:
+                    new_profile = "default profile"
                 self.applescript.append('tell current window')
-                self.applescript.append('create tab with default profile')
+                self.applescript.append('create tab with {prof}'.format(prof=new_profile))
                 self.applescript.append('end tell')
                 # self.applescript.append('create window with default profile')
             else:
@@ -132,7 +136,7 @@ class Itermocil(object):
 
         return parsed_script
 
-    def arrange_panes(self, num_panes, layout="tiled"):
+    def arrange_panes(self, num_panes, current_window, layout="tiled"):
         """ Create a set of Applescript instructions to generate the desired
             layout of panes. Attempt to match teamocil layout behaviour as
             closely as is possible.
@@ -141,12 +145,19 @@ class Itermocil(object):
             generating a version for old iTerm.
         """
 
+        panes = self.teamocil_config['windows'][current_window]['panes']
+
         def create_pane(parent, child, split="vertical"):
 
+            if 'profile' in self.teamocil_config['windows'][current_window]['panes'][child-1]:
+                profile = 'profile "' + panes[child-1]['profile'] + '"'
+            else:
+                profile = "same profile"
+
             return (''' tell pane_{pp}
-                            set pane_{cp} to (split {o}ly with same profile)
+                            set pane_{cp} to (split {o}ly with {prof})
                         end tell
-                    '''.format(pp=parent, cp=child, o=split))
+                    '''.format(pp=parent, cp=child, o=split, prof=profile))
 
         # Link a variable to the current window.
         self.applescript.append("set pane_1 to (current session of current window)")
@@ -491,8 +502,12 @@ class Itermocil(object):
         for num, window in enumerate(teamocil_config['windows']):
             if num > 0:
                 if self.new_iterm:
+                    if 'profile' in self.teamocil_config['windows'][num]['panes'][0]:
+                        new_profile = 'profile "' + self.teamocil_config['windows'][num]['panes'][0]['profile'] + '"'
+                    else:
+                        new_profile = "default profile"
                     self.applescript.append('tell current window')
-                    self.applescript.append('create tab with default profile')
+                    self.applescript.append('create tab with {prof}'.format(prof=new_profile))
                     self.applescript.append('end tell')
                     # self.applescript.append('create window with default profile')
                 else:
@@ -525,7 +540,7 @@ class Itermocil(object):
             # Generate Applescript to lay the panes out and then add to our
             # Applescript commands to run.
             if self.new_iterm:
-                self.arrange_panes(len(window['panes']), layout)
+                self.arrange_panes(len(window['panes']), num, layout)
             else:
                 self.arrange_panes_old_iterm(len(window['panes']), layout)
 

--- a/itermocil.py
+++ b/itermocil.py
@@ -145,12 +145,10 @@ class Itermocil(object):
             generating a version for old iTerm.
         """
 
-        panes = self.teamocil_config['windows'][current_window]['panes']
-
         def create_pane(parent, child, split="vertical"):
 
             if 'profile' in self.teamocil_config['windows'][current_window]['panes'][child-1]:
-                profile = 'profile "' + panes[child-1]['profile'] + '"'
+                profile = 'profile "' + self.teamocil_config['windows'][current_window]['panes'][child-1]['profile'] + '"'
             else:
                 profile = "same profile"
 


### PR DESCRIPTION
added preliminary support for specifying a certain iTerm profile to use with each pane. The yaml file now looks like this:

``` yaml
windows:
  - name: github.io
    root: ~/Sites/galaxyutii.github.io
    layout: main-vertical
    panes:
      - name: "github.io"
        commands: 
        - clear
        focus: true
      - name: "github.io: jekyll"
        commands:
        - bundle install
        - clear
        - bundle exec jekyll build --quiet
        - bundle exec jekyll serve --watch
        profile: jekyll
      - name: "github.io: git"
        commands: 
        - clear
        - git status
        profile: git
```

not specifying a profile in the yaml will result in the first pane (tab) being created with the default profile and any following panes to be created with the same profile as the pane who created it (the previous behavior)
