### PR TITLE
Add functionality to start all windows in the cwd

### DIFF
--- a/itermocil.py
+++ b/itermocil.py
@@ -530,7 +530,10 @@ class Itermocil(object):
 
             # Extract starting directory for panes in this window, if given.
             if 'root' in window:
-                if window['root']:
+                if window['root'] == 'cwd':
+                    parsed_path = os.getcwd().replace(" ", "\\\ ")
+                    base_command.append('cd {path}'.format(path=parsed_path))
+                elif window['root']:
                     parsed_path = window['root'].replace(" ", "\\\ ")
                     base_command.append('cd {path}'.format(path=parsed_path))
                 else:


### PR DESCRIPTION
I needed a way to open new windows in the same directory as the itermocil command is run and `--here` doesn't propagate to all new windows.

Not sure if this is the best way to do it (never coded python), but the feature would be very useful.

Cheers.