### PR TITLE
Fix readme for pane-less window

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,6 @@ windows:
   - name: pane-less
     root: ~/Code/sample/www
     command: rails console
-windows:
   - name: one_more-pane-less
     root: ~/Code/sample/www
     commands:


### PR DESCRIPTION
The README gives a wrong example of how tu use pane-less windows, as pointed out in https://github.com/TomAnthony/itermocil/issues/58