### PR TITLE
Add here to window config

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ iTermocil is compatible with all of teamocil's flags, and they all work in the s
 | `command`  | A command to run in the current window. Ignored if `panes` is present
 | `commands` | An array of commands for run in the current window. Ignored if either `panes` or `command `is present
 | `focus`    | This is currently unsupported in iTermocil
-
+| `here`     | Uses the current window as the layout’s first window. Only a single window can have this option
 
 ### Panes
 

--- a/itermocil.py
+++ b/itermocil.py
@@ -62,7 +62,7 @@ class Itermocil(object):
 
         # If we need to open a new window, then add necessary commands
         # to script.
-        if not self.here:
+        if not self.use_current_window():
             if self.new_iterm:
                 self.applescript.append('tell current window')
                 self.applescript.append('create tab with default profile')
@@ -488,6 +488,15 @@ class Itermocil(object):
                 self.applescript.append('tell i term application "System Events" ' +
                                         'to keystroke "]" using command down')
 
+    def use_current_window(self):
+        return self.here or self.windows_with_here_count() > 0
+
+    def windows_with_here_count(self):
+        return len(filter(lambda w: w.get('here', False), self.parsed_config['windows']))
+
+    def windows_with_here_first(self):
+        return sorted(self.parsed_config['windows'], key=lambda w: w.get('here', False), reverse=True)
+
     def process_file(self):
         """ Parse the named iTermocil file, generate Applescript to send to
             iTerm2 to generate panes, name them and run the specified commands
@@ -500,14 +509,18 @@ class Itermocil(object):
             total_pane_count = 0
         else:
             total_pane_count = int(self.get_num_panes_in_current_window())
-            if self.here:
+            if self.use_current_window():
                 total_pane_count -= 1
 
         if 'windows' not in self.parsed_config:
             print "ERROR: No windows defined in " + self.file
             sys.exit(1)
 
-        for num, window in enumerate(self.parsed_config['windows']):
+        if self.windows_with_here_count() > 1:
+            print "ERROR: Multiple windows can not set 'here' in " + self.file
+            sys.exit(1)
+
+        for num, window in enumerate(self.windows_with_here_first()):
             if num > 0:
                 if self.new_iterm:
                     self.applescript.append('tell current window')
@@ -534,7 +547,7 @@ class Itermocil(object):
                     parsed_path = window['root'].replace(" ", "\\\ ")
                     base_command.append('cd {path}'.format(path=parsed_path))
                 else:
-                    if self.here:
+                    if window.get('here', False):
                         parsed_path = self.cwd.replace(" ", "\\\ ")
                         base_command.append('cd {path}'.format(path=parsed_path))
                     pass


### PR DESCRIPTION
Potential fix for #70 

I've added a `here` option to the `window` configuration. It allows me to specify which window will replace the window invoking the `itermocil` command.

I manually tested this out with this layout file:

```yaml
windows:
  - name: one
    root: ~/
    layout: main-vertical-flipped
    panes:
      - commands:
          - echo "w1 p1"
      - commands:
          - echo "w1 p2"
  - name: two
    here: true
    root: ~/
    layout: main-vertical-flipped
    panes:
      - commands:
          - echo "w2 p1"
          - echo "this should be the terminal that executed itermocil"
      - commands:
          - echo "w2 p2"

```

My python is probably not that pythonic, but rather more Ruby-ish 😃 