### PR TITLE
check that file exists in .teamocil before changing filepath

### DIFF
--- a/itermocil.py
+++ b/itermocil.py
@@ -695,8 +695,10 @@ def main():
 
         if not filepath:
             filepath = os.path.join(itermocil_dir, layout + ".yml")
-            if not os.path.isfile(filepath):
-                filepath = os.path.join(teamocil_dir, layout + ".yml")
+            if not os.path.isfile(filepath) and os.path.isdir(teamocil_dir):
+                teamocil_file_path = os.path.join(teamocil_dir, layout + ".yml")
+                if os.path.isfile(teamocil_file_path):
+                    filepath = teamocil_file_path
 
     # If --edit the try to launch editor and exit
     if args.edit:


### PR DESCRIPTION
Was not able to follow the README directions because the script was changing the filepath to ".teamocil" when editing a new file.  This keeps the new file being edited under the ".itermocil" folder.