### PR TITLE
Fix issue caused by non-ASCII named paths

### DIFF
--- a/itermocil.py
+++ b/itermocil.py
@@ -9,6 +9,8 @@ import yaml
 
 from math import ceil
 
+reload(sys)
+sys.setdefaultencoding('utf-8')
 
 __version__ = '0.2.2'
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/Cellar/itermocil/0.2.1/libexec/bin/itermocil", line 6, in <module>
    main()
  File "/usr/local/Cellar/itermocil/0.2.1/libexec/bin/itermocil.py", line 729, in main
    instance = Itermocil(filepath, here=args.here, cwd=cwd)
  File "/usr/local/Cellar/itermocil/0.2.1/libexec/bin/itermocil.py", line 78, in __init__
    self.process_file()
  File "/usr/local/Cellar/itermocil/0.2.1/libexec/bin/itermocil.py", line 535, in process_file
    base_command.append('cd {path}'.format(path=parsed_path))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u4e2d' in position 30: ordinal not in range(128)
```