### PR TITLE
toggle broadcast input to created panes

### DIFF
--- a/itermocil.py
+++ b/itermocil.py
@@ -75,9 +75,19 @@ class Itermocil(object):
         # Process the file, building the script.
         self.process_file()
 
-        if self.broadcast:
-            self.applescript.append('tell application "System Events" ' +
+        match self.broadcast:
+            case 'panes':
+                self.applescript.append('tell application "System Events" ' +
                                         'to keystroke "i" using {option down, command down}')
+
+            case 'none':
+                # do nothing
+                pass
+
+            case _:
+                print("ERROR: broadcast mode not supported")
+                sys.exit(1)
+
 
         # Finish the script
         self.applescript.append('end tell')
@@ -544,8 +554,9 @@ class Itermocil(object):
                 print('no root!')
 
             if 'broadcast' in window:
-                self.broadcast = "panes"
-
+                self.broadcast = window['broadcast']
+            else:
+                self.broadcast = "none"
 
             # Generate Applescript to lay the panes out and then add to our
             # Applescript commands to run.

--- a/itermocil.py
+++ b/itermocil.py
@@ -75,6 +75,10 @@ class Itermocil(object):
         # Process the file, building the script.
         self.process_file()
 
+        if self.broadcast:
+            self.applescript.append('tell application "System Events" ' +
+                                        'to keystroke "i" using {option down, command down}')
+
         # Finish the script
         self.applescript.append('end tell')
 
@@ -538,6 +542,10 @@ class Itermocil(object):
                     pass
             else:
                 print('no root!')
+
+            if 'broadcast' in window:
+                self.broadcast = "panes"
+
 
             # Generate Applescript to lay the panes out and then add to our
             # Applescript commands to run.

--- a/test_layouts/_even_horizontal_3_panes_w_broadcas_input.yml
+++ b/test_layouts/_even_horizontal_3_panes_w_broadcas_input.yml
@@ -1,0 +1,9 @@
+windows:
+  - name: _even_horizontal_3_panes
+    root: ~
+    layout: even-horizontal
+    broadcast: panes
+    panes:
+      - echo "pane 1"
+      - echo "pane 2"
+      - echo "pane 3"


### PR DESCRIPTION
Added a new property `broadcast` to the configuration in order to broadcast the input to all created panes.
Example of the new configuration.
`windows:
  - name: with_broadcast
    root: ~
    broadcast: panes
    layout: even-vertical
    panes:
      - ssh server1
      - ssh server2`