### PR TITLE
Update panes naming

### DIFF
--- a/itermocil.py
+++ b/itermocil.py
@@ -52,6 +52,7 @@ class Itermocil(object):
 
         # This will be where we build up the script.
         self.applescript = []
+        self.applescript_end = []
         self.applescript.append('tell application "iTerm"')
         self.applescript.append('activate')
 
@@ -74,6 +75,10 @@ class Itermocil(object):
 
         # Process the file, building the script.
         self.process_file()
+
+        # Join end commands to main script
+        self.applescript.append("delay 1")
+        self.applescript.extend(self.applescript_end)
 
         # Finish the script
         self.applescript.append('end tell')
@@ -450,9 +455,15 @@ class Itermocil(object):
         self.applescript.append(
             ''' tell {tell_target}
                     write text "{command}"
+                end tell
+            '''.format(tell_target=tell_target, command=command))
+
+        # Build the applescript end snippet.
+        self.applescript_end.append(
+            ''' tell {tell_target}
                     {name}
                 end tell
-            '''.format(tell_target=tell_target, command=command, name=name_command))
+            '''.format(tell_target=tell_target, name=name_command))
 
     def initiate_window(self, commands=None):
         """ Runs the list of commands in the current pane

--- a/test_layouts/_named_pane.yml
+++ b/test_layouts/_named_pane.yml
@@ -1,0 +1,9 @@
+windows:
+  - name: _named_pane
+    root: ~
+    layout: tiled
+    panes:
+      - command: 'echo pane 1'
+        name: 'Pane 1'
+      - command: 'echo pane 2'
+        name: 'Pane 2'


### PR DESCRIPTION
Pane names were not being set. Delay has been added between command executions and setting pane names. This now sets pane names as expected.